### PR TITLE
Fix Unit Tests

### DIFF
--- a/services/src/test/resources/conf/portal/configuration.xml
+++ b/services/src/test/resources/conf/portal/configuration.xml
@@ -37,5 +37,7 @@
 
     <remove-configuration>org.exoplatform.commons.search.index.IndexingOperationProcessor</remove-configuration>
     <remove-configuration>org.exoplatform.commons.search.rest.IndexingManagementRestServiceV1</remove-configuration>
+    <remove-configuration>org.exoplatform.commons.dlp.service.DlpPositiveItemService</remove-configuration>
+    <remove-configuration>org.exoplatform.commons.dlp.rest.DlpItemRestServices</remove-configuration>
 
 </configuration>


### PR DESCRIPTION
Gamification Github connector is failing due to services definition changes in upper layer that isn't transparent.
The fix here is to remove unnecessary services configuration that are making the build fails