### PR TITLE
Fix: Github connector repos not updated when changing organization - MEED-2454 - Meeds-io/MIPs#64

### DIFF
--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/GithubConsumerService.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/GithubConsumerService.java
@@ -67,11 +67,8 @@ public interface GithubConsumerService {
    * Retrieve available github organization repositories.
    *
    * @param webHook webHook
-   *          repositories
-   * @throws ObjectNotFoundException when the github organization identified by
-   *           its technical name is not found
-   * @throws IllegalAccessException when user is not authorized to access remote
-   *           organization repositories
+   * @param page page
+   * @param perPage perPage
    *
    * @return {@link List} of {@link RemoteRepository}
    */
@@ -83,7 +80,6 @@ public interface GithubConsumerService {
    * Count github organization repositories.
    *
    * @param webHook webHook
-   *          repositories
    *
    * @return repositories count
    */

--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/GithubConsumerService.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/GithubConsumerService.java
@@ -77,7 +77,7 @@ public interface GithubConsumerService {
    */
   List<RemoteRepository> retrieveOrganizationRepos(WebHook webHook,
                                                    int page,
-                                                   int perPage) throws IllegalAccessException, ObjectNotFoundException;
+                                                   int perPage);
 
   /**
    * Count github organization repositories.

--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/impl/GithubConsumerServiceImpl.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/impl/GithubConsumerServiceImpl.java
@@ -47,7 +47,7 @@ public class GithubConsumerServiceImpl implements GithubConsumerService {
 
   @Override
   public int countOrganizationRepos(WebHook webHook) {
-    return githubConsumerStorage.countOrganizationRepos(webHook);
+    return githubConsumerStorage.countOrganizationRepos(webHook.getOrganizationId(), webHook.getToken());
   }
 
   @Override
@@ -62,8 +62,8 @@ public class GithubConsumerServiceImpl implements GithubConsumerService {
   }
 
   @Override
-  public List<RemoteRepository> retrieveOrganizationRepos(WebHook webHook, int page, int perPage) throws IllegalAccessException {
-    return githubConsumerStorage.retrieveOrganizationRepos(webHook, page, perPage);
+  public List<RemoteRepository> retrieveOrganizationRepos(WebHook webHook, int page, int perPage) {
+    return githubConsumerStorage.retrieveOrganizationRepos(webHook.getOrganizationId(), webHook.getToken(), page, perPage);
   }
 
   @Override

--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/storage/GithubConsumerStorage.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/storage/GithubConsumerStorage.java
@@ -88,14 +88,14 @@ public class GithubConsumerStorage {
     }
   }
 
-  public List<RemoteRepository> retrieveOrganizationRepos(WebHook webHook, int page, int perPage) {
+  public List<RemoteRepository> retrieveOrganizationRepos(long organizationId, String accessToken , int page, int perPage) {
 
     List<RemoteRepository> remoteRepositories = new ArrayList<>();
-    String url = GITHUB_API_URL + webHook.getOrganizationId() + "/repos?per_page=" + perPage + "&page=" + page;
+    String url = GITHUB_API_URL + organizationId + "/repos?per_page=" + perPage + "&page=" + page;
 
     URI uri = URI.create(url);
     try {
-      String response = processGet(uri, webHook.getToken());
+      String response = processGet(uri, accessToken);
       if (response != null) {
         Map<String, Object>[] repositoryMaps = fromJsonStringToMapCollection(response);
         for (Map<String, Object> repoMap : repositoryMaps) {
@@ -116,11 +116,11 @@ public class GithubConsumerStorage {
     return remoteRepositories;
   }
 
-  public int countOrganizationRepos(WebHook webHook) {
-    String url = GITHUB_API_URL + webHook.getOrganizationId() + "/repos";
+  public int countOrganizationRepos(long organizationId, String accessToken) {
+    String url = GITHUB_API_URL + organizationId + "/repos";
     URI uri = URI.create(url);
     try {
-      String response = processGet(uri, webHook.getToken());
+      String response = processGet(uri, accessToken);
       if (response != null) {
         Map<String, Object>[] repositoryMaps = fromJsonStringToMapCollection(response);
         return (int) Arrays.stream(repositoryMaps).count();

--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/storage/cached/model/CacheKey.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/storage/cached/model/CacheKey.java
@@ -24,7 +24,6 @@ import io.meeds.gamification.model.filter.ProgramFilter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.exoplatform.gamification.github.model.WebHook;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -32,8 +31,6 @@ import org.exoplatform.gamification.github.model.WebHook;
 public class CacheKey implements Serializable {
 
   private static final long serialVersionUID = -8995567724453740730L;
-
-  private transient WebHook webHook;
 
   private ProgramFilter     programFilter;
 
@@ -45,17 +42,11 @@ public class CacheKey implements Serializable {
 
   private String            accessToken;
 
-  private long              programId;
-
   private Integer           context;
 
-  public CacheKey(Integer context, WebHook webHook) {
-    this.webHook = webHook;
-    this.context = context;
-  }
-
-  public CacheKey(Integer context, WebHook webHook, int page, int perPage) {
-    this.webHook = webHook;
+  public CacheKey(Integer context, long organizationId, String accessToken, int page, int perPage) {
+    this.organizationId = organizationId;
+    this.accessToken = accessToken;
     this.page = page;
     this.perPage = perPage;
     this.context = context;

--- a/gamification-github-services/src/main/resources/conf/portal/gamification-github-connector-configuration.xml
+++ b/gamification-github-services/src/main/resources/conf/portal/gamification-github-connector-configuration.xml
@@ -274,29 +274,6 @@
         </object-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
-      <name>RequestReviewForPullRequest</name>
-      <set-method>addPlugin</set-method>
-      <type>io.meeds.gamification.plugin.EventConfigPlugin</type>
-      <init-params>
-        <value-param>
-          <name>event-title</name>
-          <value>requestReviewForPullRequest</value>
-        </value-param>
-        <value-param>
-          <name>event-type</name>
-          <value>github</value>
-        </value-param>
-        <value-param>
-          <name>event-trigger</name>
-          <value>pull_request</value>
-        </value-param>
-        <value-param>
-          <name>event-can-cancel</name>
-          <value>true</value>
-        </value-param>
-      </init-params>
-    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION
Prior to this change, when viewing an organization, repositories of previous organizations are listed, it's due to a cache problem
