### PR TITLE
fix: Merger PR cancels gamification for user - MEED-2441 - Meeds-io/MIPs#64

### DIFF
--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/plugin/PullRequestTriggerPlugin.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/plugin/PullRequestTriggerPlugin.java
@@ -32,7 +32,8 @@ public class PullRequestTriggerPlugin extends GithubTriggerPlugin {
     String objectId = extractSubItem(payload, PULL_REQUEST, HTML_URL);
     if (Objects.equals(extractSubItem(payload, ACTION), OPENED)) {
       return Collections.singletonList(new Event(CREATE_PULL_REQUEST_EVENT_NAME, null, userId, objectId, PR_TYPE));
-    } else if (Objects.equals(extractSubItem(payload, ACTION), CLOSED)) {
+    } else if (Objects.equals(extractSubItem(payload, ACTION), CLOSED)
+        && !Boolean.parseBoolean(extractSubItem(payload, PULL_REQUEST, MERGED))) {
       return Collections.singletonList(new Event(CLOSE_PULL_REQUEST_EVENT_NAME, null, userId, objectId, PR_TYPE));
     } else if (Objects.equals(extractSubItem(payload, ACTION), REVIEW_REQUESTED)) {
       String requestedReviewer = extractSubItem(payload, REQUESTED_REVIEWER, LOGIN);

--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/utils/Utils.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/utils/Utils.java
@@ -97,6 +97,8 @@ public class Utils {
 
   public static final String  UNLABELED                                  = "unlabeled";
 
+  public static final String  MERGED                                     = "merged";
+
   public static final String  REVIEW_REQUESTED                           = "review_requested";
 
   public static final String  REVIEW_REQUEST_REMOVED                     = "review_request_removed";


### PR DESCRIPTION
Prior to this change, the PR merger was considered as closing a PR event and canceling a gamification