### PR TITLE
fix: Cannot broadcast Github Gamification Event - meed-3143 - Meeds-io/MIPs#105

### DIFF
--- a/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/impl/GithubTriggerServiceImpl.java
+++ b/gamification-github-services/src/main/java/org/exoplatform/gamification/github/services/impl/GithubTriggerServiceImpl.java
@@ -156,9 +156,9 @@ public class GithubTriggerServiceImpl implements GithubTriggerService, Startable
       gam.put("receiverId", receiverId);
       gam.put("objectId", objectId);
       gam.put("objectType", objectType);
-      EventDTO eventDTO = eventService.getEventByTypeAndTitle("github", ruleTitle);
-      if (eventDTO != null) {
-        gam.put("ruleTitle", eventDTO.getTitle());
+      List<EventDTO> eventDTOList = eventService.getEventsByTitle(ruleTitle, 0, -1);
+      if (CollectionUtils.isNotEmpty(eventDTOList)) {
+        gam.put("ruleTitle", ruleTitle);
         listenerService.broadcast(GITHUB_ACTION_EVENT, gam, "");
       } else {
         List<EventDTO> events = eventService.getEvents(new EventFilter("github", null), 0, 0);


### PR DESCRIPTION
Before this change, GitHub events were not broadcast due to the new implementation of multiple rules with the same trigger
