### PR TITLE
fix: Delete useless ResourceRequestFilter mappings - MEED-7004 - Meeds-io/meeds#2109

### DIFF
--- a/gamification-github-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/gamification-github-webapp/src/main/webapp/WEB-INF/web.xml
@@ -59,9 +59,12 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
-	<filter-mapping>
-		<filter-name>ResourceRequestFilter</filter-name>
-		<url-pattern>/*</url-pattern>
-	</filter-mapping>
+  <filter-mapping>
+    <filter-name>ResourceRequestFilter</filter-name>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>/images/*</url-pattern>
+  </filter-mapping>
 
 </web-app>


### PR DESCRIPTION
Prior to this change, any URL was cached while the Cache HTTP Header should be applied systematically on static resources only. This change changes the Filter mapping list in order to include static resources only.

(Resolves Meeds-io/meeds#2109)