### PR TITLE
fix: Avoid using v-app in Vue components not main DOM of an app - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/gamification-github-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/GithubEventForm.vue
+++ b/gamification-github-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/GithubEventForm.vue
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app v-if="isEditing">
+  <div v-if="isEditing">
     <v-card-text class="px-0 dark-grey-color font-weight-bold">
       {{ $t('gamification.event.form.organization') }}
     </v-card-text>
@@ -77,7 +77,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </template>
       </v-autocomplete>
     </template>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/gamification-github-webapp/src/main/webapp/vue-app/githubAdminConnectorExtension/components/GithubAdminConnectorItem.vue
+++ b/gamification-github-webapp/src/main/webapp/vue-app/githubAdminConnectorExtension/components/GithubAdminConnectorItem.vue
@@ -15,7 +15,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <template v-if="!displayHookDetail">
       <div class="px-4 py-2 py-sm-5 d-flex align-center">
         <v-tooltip :disabled="$root.isMobile" bottom>
@@ -129,7 +129,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       :ok-label="$t('confirm.yes')"
       :cancel-label="$t('confirm.no')"
       @ok="deleteSettings" />
-  </v-app>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Prior to this change, the v-app was used in Vue components injected via extensionRegistry. This change will change it to simply use a simple div.