### PR TITLE
feat: Implement Github user mapping Rest API for external integrations

### DIFF
--- a/gamification-github-services/src/main/java/io/meeds/github/gamification/rest/UserMappingRest.java
+++ b/gamification-github-services/src/main/java/io/meeds/github/gamification/rest/UserMappingRest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2025 Meeds Lab contact@meedslab.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.github.gamification.rest;
+
+import org.apache.commons.lang3.StringUtils;
+import io.meeds.gamification.service.ConnectorService;
+import io.meeds.github.gamification.utils.Utils;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("mapping")
+@Tag(name = "mapping", description = "Map Github user to platform user") 
+public class UserMappingRest {
+
+    @Autowired
+    private ConnectorService      connectorService;
+
+    @GetMapping(path = "{githubId}")
+    @Secured("users")
+    public String getUserIdByGithubId(HttpServletRequest request,
+                                    @Parameter(description = "Github user identifier", required = true)
+                                    @PathVariable("githubId")
+                                    String githubId) {
+        if (StringUtils.isBlank(githubId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "'githubId' parameter is mandatory");
+        }
+        String userId = connectorService.getAssociatedUsername(Utils.CONNECTOR_NAME, githubId);
+        if(StringUtils.isNotEmpty(userId)) {
+            return userId;
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No user found for githubId: " + githubId);
+        }
+    }
+}

--- a/gamification-github-services/src/test/java/io/meeds/github/gamification/rest/UserMappingRestTest.java
+++ b/gamification-github-services/src/test/java/io/meeds/github/gamification/rest/UserMappingRestTest.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Lab contact@meedslab.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.github.gamification.rest;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import io.meeds.gamification.service.ConnectorService;
+import io.meeds.github.gamification.utils.Utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import io.meeds.spring.web.security.PortalAuthenticationManager;
+import io.meeds.spring.web.security.WebSecurityConfiguration;
+import jakarta.servlet.Filter;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(classes = { UserMappingRest.class, PortalAuthenticationManager.class, })
+@ContextConfiguration(classes = { WebSecurityConfiguration.class })
+@AutoConfigureWebMvc
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(MockitoExtension.class)
+class UserMappingRestTest {
+
+  private static final String   REST_PATH = "/mapping"; // NOSONAR
+
+  @MockBean
+  private ConnectorService  connectorService;
+
+  @Autowired
+  private SecurityFilterChain   filterChain;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  private MockMvc               mockMvc;
+
+  private static final String   SIMPLE_USER   = "simple";
+
+  private static final String   TEST_PASSWORD = "testPassword";
+
+  private static final String   GITHUB_USER   = "testUser";
+
+  @BeforeEach
+  void setup() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).addFilters(filterChain.getFilters().toArray(new Filter[0])).build();
+  }
+
+  @Test
+  void getUserIdByGithubId() throws Exception {
+    when(connectorService.getAssociatedUsername(Utils.CONNECTOR_NAME, GITHUB_USER)).thenReturn(SIMPLE_USER);
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/" + GITHUB_USER).with(testSimpleUser()));
+    response.andExpect(status().isOk()).andExpect(content().string(SIMPLE_USER));
+  }
+
+  private RequestPostProcessor testSimpleUser() {
+    return user(SIMPLE_USER).password(TEST_PASSWORD).authorities(new SimpleGrantedAuthority("users"));
+  }
+
+}


### PR DESCRIPTION
This PR introduces a new REST API endpoint to map GitHub user identifiers to platform user IDs. This will allow external integration such as task notifications etc,...