### PR TITLE
fix: Gamification Achievement Log Level - Meeds-io/meeds#3600

### DIFF
--- a/gamification-github-services/src/main/java/io/meeds/github/gamification/services/impl/GithubTriggerServiceImpl.java
+++ b/gamification-github-services/src/main/java/io/meeds/github/gamification/services/impl/GithubTriggerServiceImpl.java
@@ -168,7 +168,7 @@ public class GithubTriggerServiceImpl implements GithubTriggerService, Startable
           }
         }
       }
-      LOG.info("Github action {} broadcasted for user {}", event.getName(), senderId);
+      LOG.debug("Github action {} broadcasted for user {}", event.getName(), senderId);
     } catch (Exception e) {
       LOG.error("Cannot broadcast github event", e);
     }


### PR DESCRIPTION
This change will use DEBUG level for Gamification Github Achievements to not pollute logs.

Resolves Meeds-io/meeds#3600